### PR TITLE
Make public 3326_EmuELEC

### DIFF
--- a/README
+++ b/README
@@ -1,4 +1,3 @@
-UBIBoot
 
 UBIBoot is a very small and simple bootloader for Ingenic JZ47xx based boards, which is able to start a Linux kernel located on a UBI partition.
 


### PR DESCRIPTION
Hello,

I wasn't sure how else to reach you.  I'm looking for the source for the OS of the RG351P. I found this in the `/etc/os-release`
`BUG_REPORT_URL="https://github.com/ThinkerClimb/3326_EmuELEC"`

I read somewhere that the source was planned to be made available eventually. Honestly, I'm mostly  just looking for uboot and the kernel, as well as any userspace changes, so that I can build a Debian system for my 351p. But I would love to have the full source for the build too.

Thanks!
-- Ben